### PR TITLE
feat: 2.5x faster model generation (and 2.5x lower Replicate bill)

### DIFF
--- a/src/app/api/vicuna13b/route.ts
+++ b/src/app/api/vicuna13b/route.ts
@@ -108,7 +108,7 @@ export async function POST(request: Request) {
   // Call Replicate for inference
   const model = new Replicate({
     model:
-      "replicate/vicuna-13b:6282abe6a492de4145d7bb601023762212f9ddbbe78278bd6771c8b3b2f2a13b",
+      "moinnadeem/fastervicuna_13b:3a6afcc1c17c0384a559d6238b0fcac2483589aa689cee6abec98b1ddc648578",
     input: {
       max_length: 2048,
     },


### PR DESCRIPTION
🔥 work on the companion app!

I've been hacking around on low-latency inference recently on Replicate. This PR swaps out the default Vicuna model for a model with ~2.5x faster generation (depending on the sequence length). 

It's just a base Replicate model, so we can just swap out the model string: https://replicate.com/moinnadeem/fastervicuna_13b
We could also work on getting these things upstreamed to the main Replicate model too.

WIP: 
- a 3x improvement on latency

Things to test:
- Does streaming generation work?